### PR TITLE
Refactor code, add sandbox and fix connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,42 @@
+# LVLUP Payment Library
 lvlup-payment PHP class
 https://www.lvlup.pro/
 
-Can be installed by Composer.
-
+# Installation
+Run `composer require` to download dependencies.
 ```
 composer require kgrzelak/lvlup-payment
 ```
 
-Example
+That's all!.
 
-Base
-```
+# Example
+
+## Initialization
+
+```php
 <?php
+
 use \kgrzelak\lvlup\Payments;
+
 require_once('vendor/autoload.php');
 
 $lvlup = new Payments('api_key_from_lvlup_panel');
 ```
 
-Generating trasnsaction
-```
-$lvlup->set_payment('amount', '24.00');
-$lvlup->set_payment('redirectUrl', '');
-$lvlup->set_payment('webhookUrl', '');
-if (!$lvlup->transaction_generate()) {
-	echo 'ojoj';
-	exit();
-}
-echo 'płać i płacz ';
+## Generating trasnsaction
+```php
+$lvlup->setPaymentDetails('12.00', 'https://example.com', 'https://example.com');
 //Transaction url
-echo $lvlup->transaction_redirect();
+echo $lvlup->generateTransaction();
 ```
 
-Transaction info
-```
-$lvlup->transaction_info('transaction_id'); //bolean
+## Transaction info
+```php
+$lvlup->getTransactionInfo('transaction_id'); // boolean (paid or not paid :P)
 ```
 
-Transactions list
-```
-$lvlup->payments_get(); //array
+## Transactions list
+```php
+$lvlup->getPayments(); //array
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"minimum-stability": "stable",
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "symfony/http-client": "^5.0"
     },
     "authors": [
         {
@@ -18,5 +19,8 @@
         "psr-4": {
             "kgrzelak\\lvlup\\": "src"
         }
-	}
+	},
+    "require-dev": {
+        "phpunit/phpunit": "^9.1"
+    }
 }

--- a/examples/GenerateTransactionExample.php
+++ b/examples/GenerateTransactionExample.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once('vendor/autoload.php');
+
+use \kgrzelak\lvlup\Payments;
+
+$lvlup = new Payments('TOKEN_API');
+$lvlup->setPaymentDetails('21.00', 'https://example.com', 'https://example.com');
+
+var_dump($lvlup->generateTransaction()); // transaction url

--- a/src/Payments.php
+++ b/src/Payments.php
@@ -23,11 +23,11 @@ class Payments {
      * @param string $apiKey    Key generated from panel to access API.
      * @param bool   $sandbox   Info about using sandbox or production environment. Default production.
      */
-	public function __construct(string $apiKey, bool $sandbox = false)
+    public function __construct(string $apiKey, bool $sandbox = false)
     {
-		$this->apiKey  = $apiKey;
+        $this->apiKey  = $apiKey;
         $this->sandbox = $sandbox;
-	}
+    }
 	
     /**
      * Config method of creating new payment. You should call this
@@ -37,18 +37,18 @@ class Payments {
      * @param string $redirectUri   User will be redirected after payment to this uri.
      * @param string $webhookUrl    Endpoint for receiving payment changes
      */
-	public function setPaymentDetails(string $amount, string $redirectUri, string $webhookUrl): void
+    public function setPaymentDetails(string $amount, string $redirectUri, string $webhookUrl): void
     {
         if (empty($amount) || empty($redirectUri) || empty($webhookUrl)) {
-            throw new \IllegalArgumentException();
+            throw new \Exception();
         }
         
-		$this->requestPayment = [
+        $this->requestPayment = [
             'amount' => $amount,
             'redirecturi' => $redirectUri,
             'webhookUrl' => $webhookUrl
         ];
-	}
+    }
 	
     /**
      * Generates transaction and returns address to payment.
@@ -56,17 +56,17 @@ class Payments {
      *
      * @return string
      */
-	public function generateTransaction(): ?string
+    public function generateTransaction(): ?string
     {
         $content = $this->request($this->requestPayment, 'wallet/up', 'POST');
-		$array = json_decode($content, true);
+        $array = json_decode($content, true);
         
         if (!isset($array['id'])) {
             return null;
         }
 		
-		return $array['url'];
-	}
+        return $array['url'];
+    }
     
     /**
      * Returns payment status (payed - true/false)
@@ -74,12 +74,12 @@ class Payments {
      * @param string $id    ID of transaction
      * @return bool
      */
-	public function getTransactionInfo(string $id): bool
+    public function getTransactionInfo(string $id): bool
     {
         $content = $this->request([], '/wallet/up/' . $id, 'GET');
 
         return $content;
-	}
+    }
 	
     /**
      * Returns last $limit payments.
@@ -87,10 +87,10 @@ class Payments {
      * @param int $limit    Limit of returned payments. Default 10.
      * @return array
      */
-	public function getPayments(int $limit = 10): array
+    public function getPayments(int $limit = 10): array
     {
-		return json_decode($this->request([], 'payments'), true);
-	}
+        return json_decode($this->request([], 'payments'), true);
+    }
     
     /**
      * Creates account and return credentials. Available only in sandbox mode.
@@ -106,7 +106,7 @@ class Payments {
         $response = $this->request([], 'account/new', 'POST', false);
         
         return json_decode($response, true);
-	}
+    }
     
     /**
      * Used to access API.
@@ -118,7 +118,7 @@ class Payments {
      * @param bool   $authorizationHeader   If authorization header will be sent with request.
      * @return string
      */
-	private function request(array $data = [], string $url = '', string $method = 'GET', bool $authorizationHeader = true): ?string
+    private function request(array $data = [], string $url = '', string $method = 'GET', bool $authorizationHeader = true): ?string
     {
         $client;
         if (!\extension_loaded('curl')) {
@@ -152,5 +152,5 @@ class Payments {
             
             return $response->getContent();
         }
-	}
+    }
 }

--- a/src/Payments.php
+++ b/src/Payments.php
@@ -2,103 +2,155 @@
 
 namespace kgrzelak\lvlup;
 
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
+
+/**
+ * Main class of library.
+ * 
+ * @author kgrzelak <https://github.com/kgrzelak>
+ * @author error56 <https://github.com/error56>
+ *
+ */
 class Payments {
 	
-	protected $api_key = '';
+    private $apiKey = '';
+    private $result = '';
+    private $requestPayment = [];
+    private $sandbox = false;
 	
-	protected $result = null;
-	
-	protected $request_payment = [
-		'amount' => '',
-		'redirectUrl' => '',
-		'webhookUrl' => ''
-	];
-	
-	public function __construct(string $api_key) {
-		$this->api_key = $api_key;
+    /**
+     * @param string $apiKey    Key generated from panel to access API.
+     * @param bool   $sandbox   Info about using sandbox or production environment. Default production.
+     */
+	public function __construct(string $apiKey, bool $sandbox = false)
+    {
+		$this->apiKey  = $apiKey;
+        $this->sandbox = $sandbox;
 	}
 	
-	public function set_payment(string $name, $data) {
-		return $this->request_payment[$name] = $data;
+    /**
+     * Config method of creating new payment. You should call this
+     * before creating new transaction and getting uri for payment.
+     * 
+     * @param string $amount        Payment amount in format 'XX.YY', e.g. '21.00'
+     * @param string $redirectUri   User will be redirected after payment to this uri.
+     * @param string $webhookUrl    Endpoint for receiving payment changes
+     */
+	public function setPaymentDetails(string $amount, string $redirectUri, string $webhookUrl): void
+    {
+        if (empty($amount) || empty($redirectUri) || empty($webhookUrl)) {
+            throw new \IllegalArgumentException();
+        }
+        
+		$this->requestPayment = [
+            'amount' => $amount,
+            'redirecturi' => $redirectUri,
+            'webhookUrl' => $webhookUrl
+        ];
 	}
 	
-	public function transaction_generate() {
+    /**
+     * Generates transaction and returns address to payment.
+     * Before calling this function you should call setPaymentDetails()
+     *
+     * @return string
+     */
+	public function generateTransaction(): ?string
+    {
+        $content = $this->request($this->requestPayment, 'wallet/up', 'POST');
+		$array = json_decode($content, true);
+        
+        if (!isset($array['id'])) {
+            return null;
+        }
 		
-		if (!$api = $this->request_get('wallet/up', 'post', $this->request_payment)) {
-			return false;
-		}
-		
-		if (!isset($api->id)) {
-			return false;
-		}
-		
-		$this->result = $api;
-		
-		return true;
-		
+		return $array['url'];
+	}
+    
+    /**
+     * Returns payment status (payed - true/false)
+     * 
+     * @param string $id    ID of transaction
+     * @return bool
+     */
+	public function getTransactionInfo(string $id): bool
+    {
+        $content = $this->request([], '/wallet/up/' . $id, 'GET');
+
+        return $content;
 	}
 	
-	public function transaction_redirect() {
-		
-		if (!isset($this->result->url)) {
-			return false;
-		}
-		
-		return $this->result->url;
-		
+    /**
+     * Returns last $limit payments.
+     * 
+     * @param int $limit    Limit of returned payments. Default 10.
+     * @return array
+     */
+	public function getPayments(int $limit = 10): array
+    {
+		return json_decode($this->request([], 'payments'), true);
 	}
-	
-	public function transaction_info(string $id) {
-		
-		$api = $this->request_get('', 'get', ['wallet', 'up', $id]);
-		if ($api->payed) {
-			return true;
-		} else {
-			return false;
-		}
-		
+    
+    /**
+     * Creates account and return credentials. Available only in sandbox mode.
+     *
+     * @return array
+     */
+    public function createAccount(): array
+    {
+        if (!$this->sandbox) {
+            throw new \BadMethodCallException('Payments::createAccount available only in sandbox mode.');
+        }
+        
+        $response = $this->request([], 'account/new', 'POST', false);
+        
+        return json_decode($response, true);
 	}
-	
-	public function payments_get(int $limit = 10) {
-		return $this->request_get('payments');
+    
+    /**
+     * Used to access API.
+     * Uses curl client if extension exists, native streams otherwise.
+     * 
+     * @param array  $data                  Post data
+     * @param string $url                   URL to access.
+     * @param string $method                Request method. Currently support only GET and POST.
+     * @param bool   $authorizationHeader   If authorization header will be sent with request.
+     * @return string
+     */
+	private function request(array $data = [], string $url = '', string $method = 'GET', bool $authorizationHeader = true): ?string
+    {
+        $client;
+        if (!\extension_loaded('curl')) {
+            $client = new NativeHttpClient();
+        } else {
+            $client = new CurlHttpClient();
+        }
+        
+        $url = $this->sandbox ? 'https://sandbox-api.lvlup.pro/v4/' . $url : 'https://api.lvlup.pro/v4/' . $url;
+        
+        if ('POST' === $method) {
+            $requestData = [];
+            $requestData['body'] = json_encode($data);
+            
+            if ($authorizationHeader) {
+                $requestData['auth_bearer'] = $this->apiKey;
+            }
+            
+            $response = $client->request('POST', $url, $requestData);
+            
+            return $response->getContent();
+        } else {
+            $requestData = [];
+            $requestData['query'] = $data;
+            
+            if ($authorizationHeader) {
+                $requestData['auth_bearer'] = $this->apiKey;
+            }
+            
+            $response = $client->request('GET', $url, $requestData);
+            
+            return $response->getContent();
+        }
 	}
-	
-	private function request(array $data, $url, string $method = "get") {
-		$ch = curl_init();
-		if ($method == "post") {
-			curl_setopt($ch, CURLOPT_URL, $url);
-			curl_setopt($ch, CURLOPT_POST, true);
-			curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
-		} else {
-			$params = '';
-			foreach ($data as $d) {
-				if (!next($data)) {
-					$params .= $d;
-				} else {
-					$params .= $d . '/';
-				}
-			}
-			curl_setopt($ch, CURLOPT_URL, $url . $params);
-		}
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_FAILONERROR, true);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, ["Authorization: Bearer " . $this->api_key]);
-		$call = curl_exec($ch);
-		$response = json_decode($call);
-		$error = curl_errno($ch);
-		curl_close($ch);
-		
-		if ($error > 0) {
-			//throw new RuntimeException('CURL ERROR Code: ' . $error);
-			return false;
-		}
-		
-		return $response;
-	}
-	
-	private function request_get($value, string $method = "get", array $data = []) {
-		return $this->request($data, 'https://api.lvlup.pro/v4/' . $value, $method);
-	}
-	
 }


### PR DESCRIPTION
Poprawiłem kod, dodałem obsługę piaskownicy (w tym tworzenie kont), oraz zamieniłem pure curl na HttpClient od Symfony. Dlaczego? Obecnie, gdy użytkownik miałby wyłączony moduł curl w php skrypt by się wysypał. HttpClient w takim przypadku zamiast curl używa operacji na socketach.
Poprawiłem też nieco readme.